### PR TITLE
Update to Mantis 1.2.19 and Redmine 2.6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Description
   * Custom fields of the type multi list are not supported in Redmine.
   * Custom fields of the type checkbox with multiple values will be translated to simple lists.
   * Migrates only attachment files which are stored in the database (default).
-  * Tested only with Mantis 1.2.0 (current) and Redmine 0.9.3 (debian current).
+  * Tested only with Mantis 1.2.19 and Redmine 2.6.6
   * Make a backup of your Redmine database BEFORE you run the script (eg mysqldump..)!
 
 
@@ -66,3 +66,9 @@ After the script finishes successfully check your Redmine installation. Probably
 The last step is to copy all exported attachment files (default in `./attachments/` folder) in your Redmine file directory (in a "normal" Redmine installation this would be `/files` in your Redmine base dir; if you installed via debian apt-get it is in `/var/lib/redmine/default/files`).
 
 Done.
+
+Known Issues
+------------
+
+Versions are not correctly assigned to projects if a version with the same name already exists in another project. E.g.If projects 'A' and 'B' both have a version named '1.0.0' project 'B' gets the '1.0.0' of project 'A' assigned (or vice versa - the order is not deterministic!).
+

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Example:
     mantis_db_name = mantis
     mantis_db_login = mantis_user
     mantis_db_pass = mantis_password
-    
+
     redmine_db_host = localhost
     redmine_db_name = redmine
     redmine_db_login = redmine_user

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Description
 * Able to map Mantis data to coresponding Redmine data (eg users, projects and so on).
 * Fully user interactive (suggest what to map to what, but gives you the capability to change.. assume you have a highly configured Mantis installation).
 * Things you should keep in mind before migration:
-** Custom fields of the type multi list are not supported in Redmine.
-** Custom fields of the type checkbox with multiple values will be translated to simple lists.
-** Migrates only attachment files which are stored in the database (default).
-** Tested only with Mantis 1.2.0 (current) and Redmine 0.9.3 (debian current).
-** Make a backup of your Redmine database BEFORE you run the script (eg mysqldump..)!
+  * Custom fields of the type multi list are not supported in Redmine.
+  * Custom fields of the type checkbox with multiple values will be translated to simple lists.
+  * Migrates only attachment files which are stored in the database (default).
+  * Tested only with Mantis 1.2.0 (current) and Redmine 0.9.3 (debian current).
+  * Make a backup of your Redmine database BEFORE you run the script (eg mysqldump..)!
 
 
 Install

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -9,8 +9,8 @@ mantis2redmine.pl - Import Mantis database into Redmine
 This script imports provided Mantis database into existing Redmine database without destroying existing content in the redmine database. The idea is a non-destructive migration. Via user interaction re-mappings of mantis users, priojects and so on to Redmine equivalents can be performed.
 
 Tested with:
-    Redmine 0.9.3-1 stable
-    Mantis 1.2.4 stable
+    Redmine 2.6.6 stable
+    Mantis 1.2.19 stable
 
 Inspired by "migrate_from_mantis.rake" from the Redmine project.
 
@@ -745,9 +745,9 @@ SQLQUERY
                     my $documents = $dbix_mantis->query( $documents_sql, $old_id );
                     while ( my $documents_ref = $documents->hash ) {
                         print "+";
-        
+
                         unless ( $DRY ) {
-        
+
                             # write file to disk
                             my $filename = "$documents_ref->{ diskfile }";
                             my $output = "$opt{ attachment_dir }/$filename";
@@ -755,7 +755,7 @@ SQLQUERY
                             binmode $fh;
                             print $fh delete $documents_ref->{ content };
                             close $fh;
-        
+
                             # insert
                             $dbix_redmine->insert( documents => {
                                 project_id     => $map_ref->{ projects }->{ $old_id },
@@ -807,7 +807,7 @@ SQLQUERY
     print "OK\n";
 
     print "Import Members\n";
-    
+
    my $mantis_members = $dbix_mantis->query( <<SQLMEMBERS );
 SELECT
     project_id,

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -850,9 +850,9 @@ SELECT
     b.severity,
     c.id as `category_id`,
     b.summary AS `subject`,
-    DATE_FORMAT( FROM_UNIXTIME( b.date_submitted ), '%Y-%m-%d %T' ) AS `created_on`,
-    DATE_FORMAT( FROM_UNIXTIME( b.date_submitted ), '%Y-%m-%d' ) AS `start_date`,
-    DATE_FORMAT( FROM_UNIXTIME( b.last_updated ), '%Y-%m-%d %T' ) AS `updated_on`,
+    b.date_submitted AS `created_on`,
+    b.date_submitted AS `start_date`,
+    b.last_updated AS `updated_on`,
     CONCAT_WS( "\n\n", tt.description, tt.steps_to_reproduce, tt.additional_information ) AS `description`
 FROM mantis_bug_table b
 LEFT JOIN mantis_bug_text_table tt ON ( tt.id = b.bug_text_id )
@@ -862,7 +862,7 @@ SQL
     my $notes_sql = <<SQLNOTES;
 SELECT
     b.reporter_id,
-    DATE_FORMAT( FROM_UNIXTIME( b.date_submitted ), '%Y-%m-%d %T' ) AS `created_on`,
+    b.date_submitted  AS `created_on`,
     tt.note
 FROM mantis_bugnote_table b
 LEFT JOIN mantis_bugnote_text_table tt ON ( tt.id = b.bugnote_text_id )
@@ -875,7 +875,7 @@ SELECT
     b.diskfile,
     b.filename,
     b.file_type,
-    DATE_FORMAT( FROM_UNIXTIME( b.date_added ), '%Y-%m-%d %T' ) AS `created_on`,
+    b.date_added AS `created_on`,
     CONCAT_WS( "\n", b.title, b.description ) AS `description`,
     b.content
 FROM mantis_bug_file_table b

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -935,17 +935,12 @@ SELECT
     b.file_type,
     FROM_UNIXTIME( b.date_added, '%Y-%m-%d %T' ) AS `created_on`,
     CONCAT_WS( "\n", b.title, b.description ) AS `description`,
-    b.content
+    b.content,
+    b.user_id
 FROM mantis_bug_file_table b
 WHERE
     b.bug_id = ?
 SQLNOTES
-
-    # get admin id for file uploads
-    my ( $admin_id ) = $dbix_redmine->query( 'SELECT id FROM users WHERE login = "admin" LIMIT 1' )->list;
-    unless ( $admin_id ) {
-        ( $admin_id ) = $dbix_redmine->query( 'SELECT id FROM users LIMIT 1' )->list;
-    }
 
     my %issue_map = ();
     while ( my $issue_ref = $issues->hash ) {
@@ -1066,7 +1061,7 @@ SQLNOTES
                         filesize       => -s $output,
                         content_type   => $attachment_ref->{ file_type },
                         created_on     => $attachment_ref->{ created_on },
-                        author_id      => $admin_id
+                        author_id      => $map_ref->{ users }->{ $attachment_ref->{ user_id } } || 2,
                     } );
                 }
                 $report{ attachments_created } ++;

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -933,7 +933,7 @@ SELECT
     b.diskfile,
     b.filename,
     b.file_type,
-    DATE_FORMAT( FROM_UNIXTIME( b.date_added ), '%Y-%m-%d %T' ) AS `created_on`,
+    FROM_UNIXTIME( b.date_added, '%Y-%m-%d %T' ) AS `created_on`,
     CONCAT_WS( "\n", b.title, b.description ) AS `description`,
     b.content
 FROM mantis_bug_file_table b

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -482,7 +482,7 @@ User interactive.
 sub import_trackers {
     my %mantis = map {
         ( $_->{ id } => $_ );
-    } $dbix_mantis->query( 'SELECT id, category as name, project_id FROM mantis_project_category_table' )->hashes;
+    } $dbix_mantis->query( 'SELECT id, category as name, project_id FROM mantis__category_table' )->hashes;
 
     my %redmine = map {
         ( $_->{ id } => $_ );
@@ -517,7 +517,7 @@ User interactive.
 sub import_categories {
     my %mantis = map {
         ( $_->{ id } => $_ );
-    } $dbix_mantis->query( 'SELECT id, category as name, project_id FROM mantis_project_category_table' )->hashes;
+    } $dbix_mantis->query( 'SELECT id, name, project_id FROM mantis_category_table' )->hashes;
 
     my %redmine = map {
         ( $_->{ id } => $_ );
@@ -816,11 +816,11 @@ sub perform_import {
                 unless ( $DRY ) {
 
                     # create category
-                    $dbix_redmine->insert( issue_categories => {
-                        name          => $name,
-                        project_id    => $project_id
-                    } );
-                    ( $map_ref->{ categories }->{ $old_id } ) = $dbix_redmine->query( 'SELECT MAX(id) FROM issue_categories' )->list;
+                    #$dbix_redmine->insert( issue_categories => {
+                    #    name          => $name,
+                    #    project_id    => $project_id
+                    #} );
+                    #( $map_ref->{ categories }->{ $old_id } ) = $dbix_redmine->query( 'SELECT MAX(id) FROM issue_categories' )->list;
                 }
 
                 $report{ categories_created } ++;
@@ -856,7 +856,7 @@ SELECT
     CONCAT_WS( "\n\n", tt.description, tt.steps_to_reproduce, tt.additional_information ) AS `description`
 FROM mantis_bug_table b
 LEFT JOIN mantis_bug_text_table tt ON ( tt.id = b.bug_text_id )
-LEFT JOIN mantis_project_category_table c ON ( c.category = b.category AND c.project_id = b.project_id )
+LEFT JOIN mantis_category_table c ON ( c.name = b.category_id AND c.project_id = b.project_id )
 SQL
 
     my $notes_sql = <<SQLNOTES;

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -482,7 +482,7 @@ User interactive.
 sub import_trackers {
     my %mantis = map {
         ( $_->{ id } => $_ );
-    } $dbix_mantis->query( 'SELECT id, name, project_id FROM mantis_category_table' )->hashes;
+    } $dbix_mantis->query( 'SELECT id, category as name, project_id FROM mantis_project_category_table' )->hashes;
 
     my %redmine = map {
         ( $_->{ id } => $_ );
@@ -517,7 +517,7 @@ User interactive.
 sub import_categories {
     my %mantis = map {
         ( $_->{ id } => $_ );
-    } $dbix_mantis->query( 'SELECT id, name, project_id FROM mantis_category_table' )->hashes;
+    } $dbix_mantis->query( 'SELECT id, category as name, project_id FROM mantis_project_category_table' )->hashes;
 
     my %redmine = map {
         ( $_->{ id } => $_ );
@@ -828,7 +828,7 @@ SELECT
     b.status,
     b.target_version,
     b.severity,
-    b.category_id,
+    c.id as `category_id`,
     b.summary AS `subject`,
     DATE_FORMAT( FROM_UNIXTIME( b.date_submitted ), '%Y-%m-%d %T' ) AS `created_on`,
     DATE_FORMAT( FROM_UNIXTIME( b.date_submitted ), '%Y-%m-%d' ) AS `start_date`,
@@ -836,6 +836,7 @@ SELECT
     CONCAT_WS( "\n\n", tt.description, tt.steps_to_reproduce, tt.additional_information ) AS `description`
 FROM mantis_bug_table b
 LEFT JOIN mantis_bug_text_table tt ON ( tt.id = b.bug_text_id )
+LEFT JOIN mantis_project_category_table c ON ( c.category = b.category AND c.project_id = b.project_id )
 SQL
 
     my $notes_sql = <<SQLNOTES;
@@ -886,7 +887,7 @@ SQLNOTES
             	# severity 10 => feature / alle anderen -> bug
                 tracker_id       => ($issue_ref->{ severity } == 10) ? $trackerIdFeature : $trackerIdBug,
                 project_id       => $map_ref->{ projects }->{ $issue_ref->{ project_id } },
-                category_id      => $map_ref->{ projects }->{ $issue_ref->{ category_id } },
+                category_id      => $map_ref->{ categories }->{ $issue_ref->{ category_id } },
                 subject          => encode( "UTF-8", $issue_ref->{ subject } ),
                 description      => encode( "UTF-8", $issue_ref->{ description } ),
                 status_id        => $map_ref->{ stati }->{ $issue_ref->{ status } }->{ id },

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -975,7 +975,7 @@ SELECT
     b.target_version,
     b.fixed_in_version,
     b.severity,
-    c.id as `category_id`,
+    b.category_id,
     b.summary AS `subject`,
     DATE_FORMAT( FROM_UNIXTIME( b.date_submitted ), '%Y-%m-%d %T' ) AS `created_on`,
     DATE_FORMAT( FROM_UNIXTIME( b.date_submitted ), '%Y-%m-%d' ) AS `start_date`,
@@ -983,7 +983,6 @@ SELECT
     CONCAT_WS( "\n\n", tt.description, tt.steps_to_reproduce, tt.additional_information ) AS `description`
 FROM mantis_bug_table b
 LEFT JOIN mantis_bug_text_table tt ON ( tt.id = b.bug_text_id )
-LEFT JOIN mantis_category_table c ON ( c.name = b.category_id AND c.project_id = b.project_id )
 SQL
 
     my $notes_sql = <<SQLNOTES;

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -890,6 +890,7 @@ SQLNOTES
                 assigned_to_id   => $map_ref->{ users }->{ $issue_ref->{ handler_id } },
                 priority_id      => $map_ref->{ priorities }->{ $issue_ref->{ priority } }->{ id },
                 author_id        => $map_ref->{ users }->{ $issue_ref->{ reporter_id } },
+                position         => 0,
                 created_on       => $issue_ref->{ created_on },
                 updated_on       => $issue_ref->{ updated_on },
                 start_date       => $issue_ref->{ start_date },

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -678,6 +678,26 @@ sub perform_import {
                     rgt         => $max+1
                 } );
                 ( $map_ref->{ projects }->{ $old_id } ) = $dbix_redmine->query( 'SELECT MAX(id) FROM projects' )->list;
+
+                $dbix_redmine->insert( enabled_modules => {
+                    project_id => $map_ref->{ projects }->{ $old_id },
+                    name       => 'issue_tracking'
+                } );
+
+                $dbix_redmine->insert( enabled_modules => {
+                    project_id => $map_ref->{ projects }->{ $old_id },
+                    name       => 'files'
+                } );
+
+                $dbix_redmine->insert( enabled_modules => {
+                    project_id => $map_ref->{ projects }->{ $old_id },
+                    name       => 'calendar'
+                } );
+
+                $dbix_redmine->insert( enabled_modules => {
+                    project_id => $map_ref->{ projects }->{ $old_id },
+                    name       => 'gantt'
+                } );
             }
 
             $report{ projects_created } ++;

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -514,7 +514,7 @@ User interactive.
 sub import_categories {
     my %mantis = map {
         ( $_->{ id } => $_ );
-    } $dbix_mantis->query( 'SELECT id, name, project_id FROM mantis_category_table' )->hashes;
+    } $dbix_mantis->query( 'SELECT id, name, project_id, user_id as assigned_to_id FROM mantis_category_table' )->hashes;
 
     my %redmine = map {
         ( $_->{ id } => $_ );
@@ -809,6 +809,7 @@ sub perform_import {
 
                 # get category probs
                 my $name       = delete $new_ref->{ name };
+                my $user_id    = delete $new_ref->{ assigned_to_id };
                 # link category to project(s)
                 my $project_id = $map_ref->{ projects }->{ delete $new_ref->{ project_id } } ;
                 my @insert = $project_id == 0 ? @project_ids : $project_id ;
@@ -818,8 +819,9 @@ sub perform_import {
                     foreach my $insert( @insert ) {
                     # create category
                         $dbix_redmine->insert( issue_categories => {
-                            name          => $name,
-                            project_id    => $insert
+                            name           => $name,
+                            assigned_to_id => $map_ref->{ users }->{ $user_id },
+                            project_id     => $insert
                         } );
                     }
                     ( $map_ref->{ categories }->{ $old_id } ) = $dbix_redmine->query( 'SELECT MAX(id) FROM issue_categories' )->list;

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -914,7 +914,6 @@ SQLNOTES
                 assigned_to_id   => $map_ref->{ users }->{ $issue_ref->{ handler_id } },
                 priority_id      => $map_ref->{ priorities }->{ $issue_ref->{ priority } }->{ id },
                 author_id        => $map_ref->{ users }->{ $issue_ref->{ reporter_id } },
-                position         => 0,
                 created_on       => $issue_ref->{ created_on },
                 updated_on       => $issue_ref->{ updated_on },
                 start_date       => $issue_ref->{ start_date },

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -847,6 +847,7 @@ SELECT
     b.priority,
     b.status,
     b.target_version,
+    b.fixed_in_version,
     b.severity,
     c.id as `category_id`,
     b.summary AS `subject`,
@@ -921,7 +922,7 @@ SQLNOTES
                 rgt              => 2,
                 fixed_version_id => $issue_ref->{ target_version } && defined $version_map{ $issue_ref->{ target_version } }
                     ? $version_map{ $issue_ref->{ target_version } }
-                    : 0
+                    : defined $version_map{ $issue_ref->{ fixed_in_version } } ? $version_map{ $issue_ref->{ fixed_in_version } } : 0
             } );
 
             # get id of the issue

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -696,20 +696,13 @@ sub perform_import {
 
                 # Add admins as manager to all projects
                 foreach my $admin_ref ( @mantis_admins ) {
-                    my $members_id = $dbix_redmine->query( 'SELECT MAX(id) FROM members' )->list;
-                    $members_id++;
-                    my $member_roles_id = $dbix_redmine->query( 'SELECT MAX(id) FROM member_roles' )->list;
-                    $member_roles_id++;
-    
                     $dbix_redmine->insert( members => {
-                        id         => $members_id,
                         project_id => $map_ref->{ projects }->{ $old_id },
                         user_id    => $map_ref->{ users }->{ $admin_ref->{ id } }
                     } );
-        
+                    my $member_id = $dbix_redmine->last_insert_id(undef, undef, undef, undef);
                     $dbix_redmine->insert( member_roles => {
-                        id        => $member_roles_id,
-                        member_id => $members_id,
+                        member_id => $member_id,
                         role_id   => $map_ref->{ roles }->{ $admin_ref->{ access_level } }->{ id }
                     } );
                 }
@@ -739,27 +732,15 @@ SQLMEMBERS
 
     while( my $member_ref = $mantis_members->hash ) {
         print ".";
-        my $members_id = $dbix_redmine->query( 'SELECT MAX(id) FROM members' )->list;
-        $members_id++;
-        my $member_roles_id = $dbix_redmine->query( 'SELECT MAX(id) FROM member_roles' )->list;
-        $member_roles_id++;
-
-        #print "member id: $members_id\n";
-        #print "project_id: $map_ref->{ projects }->{ $member_ref->{ project_id } }\n";
-        #print "user_id: $map_ref->{ users }->{ $member_ref->{ user_id } }\n";
-        #print "role id: $member_roles_id\n";
-        #print "role: $map_ref->{ roles }->{ $member_ref->{ access_level } }->{ id }\n";
 
         unless ( $DRY ) {
              $dbix_redmine->insert( members => {
-                 id         => $members_id,
                  project_id => $map_ref->{ projects }->{ $member_ref->{ project_id } },
                  user_id    => $map_ref->{ users }->{ $member_ref->{ user_id } }
              } );
-
+             my $member_id = $dbix_redmine->last_insert_id(undef, undef, undef, undef);
              $dbix_redmine->insert( member_roles => {
-                id        => $member_roles_id,
-                member_id => $members_id,
+                member_id => $member_id,
                 role_id   => $map_ref->{ roles }->{ $member_ref->{ access_level } }->{ id }
              } );
         }

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -8,7 +8,7 @@ mantis2redmine.pl - Import Mantis database into Redmine
 
 This script imports provided Mantis database into existing Redmine database without destroying existing content in the redmine database. The idea is a non-destructive migration. Via user interaction re-mappings of mantis users, priojects and so on to Redmine equivalents can be performed.
 
-Tested with: 
+Tested with:
     Redmine 0.9.3-1 stable
     Mantis 1.2.4 stable
 
@@ -99,22 +99,22 @@ my %opt;
 GetOptions(
     "dry_run|n" => \( my $DRY = 0 ),
     "help|h"    => \( $opt{ help } = 0 ),
-    
+
     "mantis_db_host=s"  => \( $opt{ mantis_db_host }  = "localhost" ),
     "mantis_db_name=s"  => \( $opt{ mantis_db_name }  = "mantis" ),
     "mantis_db_login=s" => \( $opt{ mantis_db_login } = "" ),
     "mantis_db_pass=s"  => \( $opt{ mantis_db_pass }  = "" ),
-    
+
     "redmine_db_host=s"  => \( $opt{ redmine_db_host }  = "localhost" ),
     "redmine_db_name=s"  => \( $opt{ redmine_db_name }  = "redmine" ),
     "redmine_db_login=s" => \( $opt{ redmine_db_login } = "" ),
     "redmine_db_pass=s"  => \( $opt{ redmine_db_pass }  = "" ),
-    
+
     "load_maps"  => \( $opt{ load_maps } ),
-    "config|c=s" => \( $opt{ config } = "" ), 
-    
+    "config|c=s" => \( $opt{ config } = "" ),
+
     "category_source" => \( $opt{ category_source } = "categories" ),
-    
+
     "attachment_dir=s" => \( $opt{ attachment_dir } = "attachments" )
 );
 
@@ -142,13 +142,13 @@ Options
     --attachment_dir <path>
         Direcory for outputting any attachment file.
         default: attachments (in current dir)
-    
+
     Import flavor:
     --category-source <source>
         You can either use "categories" or "trackers" as source for your
         newly created redmine categories.
         Default: "categories"
-    
+
     Mantis Database:
     --mantis_db_host <hostname>
         default: localhost
@@ -156,7 +156,7 @@ Options
         default: mantis
     --mantis_db_login <login>
     --mantis_db_pass <password>
-    
+
     Redmine Database:
     --redmine_db_host <hostname>
         default: localhost
@@ -164,7 +164,7 @@ Options
         default: redmine
     --redmine_db_login <login>
     --redmine_db_pass <password>
-    
+
 HELP
 
 
@@ -196,12 +196,12 @@ unless ( $DRY || read_in( "Are you sure you? Do you have a backup of your import
 }
 
 # open dbi
-my $dbix_mantis = DBIx::Simple->connect( 
+my $dbix_mantis = DBIx::Simple->connect(
     'DBI:mysql:database='. $opt{ mantis_db_name }. ';host='. $opt{ mantis_db_host },
     $opt{ mantis_db_login }, $opt{ mantis_db_pass },
     { RaiseError => 1 }
 );
-my $dbix_redmine = DBIx::Simple->connect( 
+my $dbix_redmine = DBIx::Simple->connect(
     'DBI:mysql:database='. $opt{ redmine_db_name }. ';host='. $opt{ redmine_db_host },
     $opt{ redmine_db_login }, $opt{ redmine_db_pass },
     { RaiseError => 1 }
@@ -226,7 +226,7 @@ foreach my $import( @import_modules ) {
     print " *** ". ucfirst( $import ). " ***\n\n";
     {
         no strict 'refs';
-        $map{ $import } = $opt{ load_maps } && -f "store-$import.map" 
+        $map{ $import } = $opt{ load_maps } && -f "store-$import.map"
             ? do {
                 print "-> Load from file\n";
                 load_map( $import )
@@ -264,7 +264,7 @@ sub import_stati {
         ( $_->{ position } => $_ )
     } $dbix_redmine->query( 'SELECT id, name, position FROM issue_statuses' )->hashes;
     my $default_ref = $redmine_stati{ 1 };
-    
+
     my %mantis_stati = (
         10 => [ "new", $redmine_stati{ 1 } ], # new
         20 => [ "feedback", $redmine_stati{ 4 } || $default_ref ], # feedback
@@ -274,7 +274,7 @@ sub import_stati {
         80 => [ "resolved", $redmine_stati{ 3 } || $default_ref ], # resolved
         90 => [ "closed", $redmine_stati{ 3 } || $default_ref ]  # closed
     );
-    
+
     return create_map( 'Status', \%mantis_stati, \%redmine_stati, $default_ref, 'position' );
 }
 
@@ -292,7 +292,7 @@ sub import_priorities {
         ( $_->{ position } => $_ )
     } $dbix_redmine->query( 'SELECT id, name, position FROM enumerations WHERE type = ?', 'IssuePriority' )->hashes;
     my $default_ref = $redmine{ 1 };
-    
+
     my %mantis = (
         10 => [ 'none', $redmine{ 1 } ], # none
         20 => [ 'low', $redmine{ 1 } ], # low
@@ -301,7 +301,7 @@ sub import_priorities {
         50 => [ 'urgent', $redmine{ 4 } || $default_ref ], # urgent
         60 => [ 'immediate', $redmine{ 5 } || $default_ref ]  # immediate
     );
-    
+
     return create_map( 'Priority', \%mantis, \%redmine, $default_ref, 'position' );
 }
 
@@ -319,7 +319,7 @@ sub import_roles {
         ( $_->{ position } => $_ )
     } $dbix_redmine->query( 'SELECT id, name, position FROM roles' )->hashes;
     my $default_ref = $redmine{ scalar keys %redmine };
-    
+
     my %mantis = (
         10 => [ 'viewer', $default_ref ],   # viewer
         25 => [ 'reporter', $redmine{ 5 } || $default_ref ],   # reporter
@@ -328,7 +328,7 @@ sub import_roles {
         70 => [ 'manager', $redmine{ 3 } || $default_ref ],   # manager
         90 => [ 'administrator', $redmine{ 3 } || $default_ref ]    # administrator
     );
-    
+
     return create_map( 'Role', \%mantis, \%redmine, $default_ref, 'position' );
 }
 
@@ -391,12 +391,12 @@ sub import_projects {
     my ( $first_mantis_id ) = sort keys %mantis;
     die "Did not find any mantis projects\n"
         unless $first_mantis_id;
-    
+
     my %redmine = map {
         ( $_->{ id } => $_ );
     } $dbix_redmine->query( 'SELECT id, name FROM projects' )->hashes;
     my ( $first_id ) = sort keys %redmine;
-    
+
     my $mantis_ref = { map {
         ( $_ => [ $mantis{ $_ }->{ name }, { name => 'new', id => -1 } ] )
     } keys %mantis };
@@ -404,18 +404,18 @@ sub import_projects {
         ( $_ => $redmine{ $_ } )
     } keys %redmine };
     premap( $mantis_ref, $redmine_ref, 'name' );
-    
+
     my $default_ref = $first_id
         ? $redmine{ $first_id }
         : { id => -1, name => '*no project found in redmine*' }
     ;
-    
+
     my $new_ref = create_map( 'Project', $mantis_ref, $redmine_ref, $default_ref, 'id', {
         allow_new     => 1,
         print_mantis  => 1,
         print_redmine => 1
     } );
-    
+
     my $ref = update_maps( $new_ref, \%mantis );
     print Dumper $ref;
     return $ref;
@@ -432,20 +432,20 @@ User interactive.
 =cut
 
 sub import_versions {
-    
+
     #my $sql_version_table = 'SELECT id, version, description, project_id, DATE_FORMAT( date, \'%Y-%m-%d\' ) as date, released FROM mantis_project_version_table';
     my $sql_version_table = 'SELECT id, version, description, project_id, released FROM mantis_project_version_table';
     my %mantis = map {
         $_->{ name } = substr( delete $_->{ version }, 0, 30 );
         ( $_->{ id } => $_ );
     } $dbix_mantis->query( $sql_version_table )->hashes;
-    
+
     my %redmine = map {
         ( $_->{ id } => $_ );
     } $dbix_redmine->query( 'SELECT id, name FROM versions' )->hashes;
     my ( $first_id ) = sort keys %redmine;
-    
-    
+
+
     my $mantis_ref = { map {
         ( $_ => [ $mantis{ $_ }->{ name }, { name => 'new', id => -1 } ] )
     } keys %mantis };
@@ -453,18 +453,18 @@ sub import_versions {
         ( $_ => $redmine{ $_ } )
     } keys %redmine };
     premap( $mantis_ref, $redmine_ref, 'name' );
-    
+
     my $default_ref = $first_id
         ? $redmine{ $first_id }
         : { id => -1, name => '*no version found in redmine*' }
     ;
-    
+
     my $new_ref = create_map( 'Version', $mantis_ref, $redmine_ref, $default_ref, 'id', {
         allow_new     => 1,
         print_mantis  => 1,
         print_redmine => 1
     } );
-    
+
     return update_maps( $new_ref, \%mantis );
 }
 
@@ -480,12 +480,12 @@ sub import_trackers {
     my %mantis = map {
         ( $_->{ id } => $_ );
     } $dbix_mantis->query( 'SELECT id, name, project_id FROM mantis_category_table' )->hashes;
-    
+
     my %redmine = map {
         ( $_->{ id } => $_ );
     } $dbix_redmine->query( 'SELECT id, name FROM trackers' )->hashes;
     my ( $first_id ) = sort keys %redmine;
-    
+
     my $mantis_ref = { map {
         ( $_ => [ $mantis{ $_ }->{ name }, { name => 'new', id => -1 } ] )
     } keys %mantis };
@@ -493,13 +493,13 @@ sub import_trackers {
         ( $_ => $redmine{ $_ } )
     } keys %redmine };
     premap( $mantis_ref, $redmine_ref, 'name' );
-    
+
     my $new_ref = create_map( 'Tracker', $mantis_ref, $redmine_ref, $redmine{ $first_id }, 'id', {
        allow_new     => 1,
        print_mantis  => 1,
        print_redmine => 1
     } );
-    
+
     return update_maps( $new_ref, \%mantis );
 }
 
@@ -515,12 +515,12 @@ sub import_categories {
     my %mantis = map {
         ( $_->{ id } => $_ );
     } $dbix_mantis->query( 'SELECT id, name, project_id FROM mantis_category_table' )->hashes;
-    
+
     my %redmine = map {
         ( $_->{ id } => $_ );
     } $dbix_redmine->query( 'SELECT id, name FROM issue_categories' )->hashes;
     my ( $first_id ) = sort keys %redmine;
-    
+
     my $mantis_ref = { map {
         ( $_ => [ $mantis{ $_ }->{ name }, { name => 'new', id => -1 } ] )
     } keys %mantis };
@@ -528,18 +528,18 @@ sub import_categories {
         ( $_ => $redmine{ $_ } )
     } keys %redmine };
     premap( $mantis_ref, $redmine_ref, 'name' );
-    
+
     my $default_ref = $first_id
         ? $redmine{ $first_id }
         : { id => -1, name => '*no category found in redmine*' }
     ;
-    
+
     my $new_ref = create_map( 'Category', $mantis_ref, $redmine_ref, $default_ref, 'id', {
         allow_new     => 1,
         print_mantis  => 1,
         print_redmine => 1
     } );
-    
+
     return update_maps( $new_ref, \%mantis );
 }
 
@@ -565,13 +565,13 @@ sub import_users {
         $_->{ login } = delete $_->{ username };
         ( $_->{ id } => $_ );
     } $dbix_mantis->query( 'SELECT id, username, realname, email, access_level >= 90 as admin FROM mantis_user_table' )->hashes;
-    
+
     my %redmine = map {
         ( $_->{ id } => $_ );
     } $dbix_redmine->query( 'SELECT id, login, firstname, lastname, mail FROM users' )->hashes;
     my ( $first_id ) = sort keys %redmine;
-    
-    
+
+
     my $mantis_ref = { map {
         ( $_ => [ $mantis{ $_ }->{ login }, { name => 'new', id => -1 } ] )
     } keys %mantis };
@@ -579,8 +579,8 @@ sub import_users {
         ( $_ => { name => $redmine{ $_ }->{ login }, id => $redmine{ $_ }->{ id } } )
     } keys %redmine };
     premap( $mantis_ref, $redmine_ref, 'name' );
-    
-    
+
+
     my $default_ref = $first_id
         ? $redmine{ $first_id }
         : {
@@ -593,13 +593,13 @@ sub import_users {
             lastname => '*no user found in redmine*',
         }
     ;
-    
+
     my $new_ref = create_map( 'User', $mantis_ref, $redmine_ref, $default_ref, 'id', {
         allow_new     => 1,
         print_mantis  => 1,
         print_redmine => 1
     } );
-    
+
     return update_maps( $new_ref, \%mantis );
 }
 
@@ -614,17 +614,17 @@ User interactive.
 
 sub perform_import {
     my ( $map_ref ) = @_;
-    
+
     my %report = ();
-    
+
     print "Import Users\n";
     while( my ( $old_id, $new_ref ) = each %{ $map_ref->{ users } } ) {
         print ".";
-        
+
         # create new user
         if ( $new_ref->{ id } == -1 ) {
             delete $new_ref->{ id };
-            
+
             unless ( $DRY ) {
                 $dbix_redmine->insert( users => {
                     %$new_ref, # firstname, lastname, login, mail, admin
@@ -633,36 +633,36 @@ sub perform_import {
                 } );
                 ( $map_ref->{ users }->{ $old_id } ) = $dbix_redmine->query( 'SELECT MAX(id) FROM users' )->list;
             }
-            
+
             $report{ users_created } ++;
         }
-        
+
         # use existing
         else {
             $map_ref->{ users }->{ $old_id } = $new_ref->{ id };
             $report{ users_migrated } ++;
         }
     }
-    print "OK\n";   
-    
+    print "OK\n";
+
     print "Import Projects\n";
     my $count = 1;
     while( my ( $old_id, $new_ref ) = each %{ $map_ref->{ projects } } ) {
         print ".";
-        
+
         # create new project
         if ( $new_ref->{ id } == -1 ) {
             delete $new_ref->{ id };
-            
+
             # get max lft/rgt
             my ( $lft, $rgt ) = $dbix_redmine->query( 'SELECT MAX( lft ), MAX(rgt) FROM projects' )->list;
             $lft ||= 0;
             $rgt ||= 0;
             my $max = $lft > $rgt ? $lft : $rgt;
             $max++;
-            
+
             unless ( $DRY ) {
-                
+
                 $dbix_redmine->insert( projects => {
                     %$new_ref, # name
                     description => 'Imported from Mantis',
@@ -676,10 +676,10 @@ sub perform_import {
                 } );
                 ( $map_ref->{ projects }->{ $old_id } ) = $dbix_redmine->query( 'SELECT MAX(id) FROM projects' )->list;
             }
-            
+
             $report{ projects_created } ++;
         }
-        
+
         # use existing
         else {
             $map_ref->{ projects }->{ $old_id } = $new_ref->{ id };
@@ -687,18 +687,18 @@ sub perform_import {
         }
     }
     print "OK\n";
-    
+
     print "Import Versions\n";
     my %version_map = ();
     while( my ( $old_id, $new_ref ) = each %{ $map_ref->{ versions } } ) {
         print ".";
-        
+
         # create new version
         if ( $new_ref->{ id } == -1 ) {
             delete $new_ref->{ id };
             my $project_id = $map_ref->{ projects }->{ delete $new_ref->{ project_id } };
             my $released   = $new_ref->{ released } ? 'closed' : 'open';
-            
+
             unless ( $DRY ) {
                 $dbix_redmine->insert( versions => {
                     name            => $new_ref->{ name },
@@ -714,10 +714,10 @@ sub perform_import {
                 $version_map{ $new_ref->{ name } } =
                 $map_ref->{ versions }->{ $old_id } = 'NEW';
             }
-            
+
             $report{ versions_created } ++;
         }
-        
+
         # use existing
         else {
             $version_map{ $new_ref->{ name } } = $map_ref->{ versions }->{ $old_id } = $new_ref->{ id };
@@ -725,25 +725,25 @@ sub perform_import {
         }
     }
     print "OK\n";
-    
+
     # use Trackers -> Categories
     if ( $opt{ category_source } eq 'trackers' ) {
         print "Import Trackers\n";
         my @project_ids = $dbix_redmine->query( 'SELECT id FROM projects' )->flat;
         while( my ( $old_id, $new_ref ) = each %{ $map_ref->{ trackers } } ) {
             print ".";
-            
+
             # create new tracker
             if ( $new_ref->{ id } == -1 ) {
                 delete $new_ref->{ id };
-                
+
                 # get tracker probs
                 my $name       = delete $new_ref->{ name };
                 my $project_id = delete $new_ref->{ project_id };
                 my ( $position ) = $dbix_redmine->query( 'SELECT MAX(position)+1 FROM trackers' )->list;
-                
+
                 unless ( $DRY ) {
-                    
+
                     # create tracker
                     $dbix_redmine->insert( trackers => {
                         name          => $name,
@@ -752,7 +752,7 @@ sub perform_import {
                         is_in_chlog   => 0,
                     } );
                     ( $map_ref->{ trackers }->{ $old_id } ) = $dbix_redmine->query( 'SELECT MAX(id) FROM trackers' )->list;
-                    
+
                     # link tracker to project(s)
                     my @insert = $project_id == 0 ? @project_ids : ( $map_ref->{ projects }->{ $project_id } );
                     foreach my $insert( @insert ) {
@@ -762,10 +762,10 @@ sub perform_import {
                         } );
                     }
                 }
-                
+
                 $report{ trackers_created } ++;
             }
-            
+
             # use existing
             else {
                 $map_ref->{ trackers }->{ $old_id } = $new_ref->{ id };
@@ -774,24 +774,24 @@ sub perform_import {
         }
         print "OK\n";
     }
-    
+
     # use Categories -> Categories (default)
     else {
         print "Import Categories\n";
         my @category_ids = $dbix_redmine->query( 'SELECT id FROM issue_categories' )->flat;
         while( my ( $old_id, $new_ref ) = each %{ $map_ref->{ categories } } ) {
             print ".";
-            
+
             # create new category
             if ( $new_ref->{ id } == -1 ) {
                 delete $new_ref->{ id };
-                
+
                 # get category probs
                 my $name       = delete $new_ref->{ name };
                 my $project_id = delete $new_ref->{ project_id };
-                
+
                 unless ( $DRY ) {
-                    
+
                     # create category
                     $dbix_redmine->insert( issue_categories => {
                         name          => $name,
@@ -799,10 +799,10 @@ sub perform_import {
                     } );
                     ( $map_ref->{ categories }->{ $old_id } ) = $dbix_redmine->query( 'SELECT MAX(id) FROM issue_categories' )->list;
                 }
-                
+
                 $report{ categories_created } ++;
             }
-            
+
             # use existing
             else {
                 $map_ref->{ categories }->{ $old_id } = $new_ref->{ id };
@@ -811,8 +811,8 @@ sub perform_import {
         }
         print "OK\n";
     }
-    
-    
+
+
     # now the hard part .. import all issues!
     print "Import Issues (. = Issue, - = Journal, + = Attachment)\n";
     my $issues = $dbix_mantis->query( <<SQL );
@@ -830,11 +830,11 @@ SELECT
     DATE_FORMAT( FROM_UNIXTIME( b.date_submitted ), '%Y-%m-%d %T' ) AS `created_on`,
     DATE_FORMAT( FROM_UNIXTIME( b.date_submitted ), '%Y-%m-%d' ) AS `start_date`,
     DATE_FORMAT( FROM_UNIXTIME( b.last_updated ), '%Y-%m-%d %T' ) AS `updated_on`,
-    CONCAT_WS( "\n\n", tt.description, tt.steps_to_reproduce, tt.additional_information ) AS `description` 
+    CONCAT_WS( "\n\n", tt.description, tt.steps_to_reproduce, tt.additional_information ) AS `description`
 FROM mantis_bug_table b
 LEFT JOIN mantis_bug_text_table tt ON ( tt.id = b.bug_text_id )
 SQL
-    
+
     my $notes_sql = <<SQLNOTES;
 SELECT
     b.reporter_id,
@@ -845,7 +845,7 @@ LEFT JOIN mantis_bugnote_text_table tt ON ( tt.id = b.bugnote_text_id )
 WHERE
     b.bug_id = ?
 SQLNOTES
-    
+
     my $attachments_sql = <<SQLNOTES;
 SELECT
     b.diskfile,
@@ -868,15 +868,15 @@ SQLNOTES
     my %issue_map = ();
     while ( my $issue_ref = $issues->hash ) {
         print ".";
-        
+
         my $issue_id;
-        
+
         #print "$issue_ref->{ id }: $issue_ref->{ target_version } -> $version_map{ $issue_ref->{ target_version } }\n" if $issue_ref->{ target_version };
         #print "is feature: $issue_ref->{ subject } ( $opt{ tracker_id_feature } )\n" if ($issue_ref->{ severity } == 10);
-        
+
         my $trackerIdFeature = ($opt{ tracker_id_feature }) ? $opt{ tracker_id_feature } : 1;
         my $trackerIdBug = ($opt{ tracker_id_bug }) ? $opt{ tracker_id_bug } : 2;
-        
+
         unless ( $DRY ) {
             # insert
             $dbix_redmine->insert( issues => my $ref = {
@@ -897,21 +897,21 @@ SQLNOTES
                     ? $version_map{ $issue_ref->{ target_version } }
                     : 0
             } );
-            
+
             # get id of the issue
             ( $issue_id ) = $dbix_redmine->query( 'SELECT MAX(id) FROM issues' )->list;
             $issue_map{ $issue_ref->{ id } } = $issue_id;
         }
-        
+
         $report{ issues_created } ++;
-        
+
         # insert notes
         my $notes = $dbix_mantis->query( $notes_sql, $issue_ref->{ id } );
         while ( my $note_ref = $notes->hash ) {
             print "-";
-            
+
             unless ( $DRY ) {
-                
+
                 # insert
                 $dbix_redmine->insert( journals => {
                     journalized_id   => $issue_id,
@@ -921,10 +921,10 @@ SQLNOTES
                     created_on       => $note_ref->{ created_on },
                 } );
             }
-            
+
             $report{ journals_created } ++;
         }
-        
+
         # insert attachments
         if (! $opt{ attachments_in_db } ) {
             my $attachments = $dbix_mantis->query( $attachments_sql, $issue_ref->{ id } );
@@ -932,9 +932,9 @@ SQLNOTES
                 # we have the attachments in the db -> exit
                 last;
                 print "+";
-                
+
                 unless ( $DRY ) {
-                    
+
                     # write file to disk
                     my $filename = "$attachment_ref->{ diskfile }_$attachment_ref->{ filename }";
                     my $output = "$opt{ attachment_dir }/$filename";
@@ -942,7 +942,7 @@ SQLNOTES
                     binmode $fh;
                     print $fh delete $attachment_ref->{ content };
                     close $fh;
-                    
+
                     # insert
                     $dbix_redmine->insert( attachments => {
                         container_id   => $issue_id,
@@ -962,7 +962,7 @@ SQLNOTES
         }
     }
     print "OK\n";
-    
+
     print "Import Relations\n";
     my $relations = $dbix_mantis->query( <<SQLRELATIONS );
 SELECT
@@ -972,10 +972,10 @@ SELECT
 FROM
     mantis_bug_relationship_table
 SQLRELATIONS
-    
+
     while( my $relation_ref = $relations->hash ) {
         print ".";
-        
+
         unless ( $DRY ) {
             $dbix_redmine->insert( issue_relations => {
                 issue_from_id => $issue_map{ $relation_ref->{ source_bug_id } },
@@ -986,7 +986,7 @@ SQLRELATIONS
         $report{ relations_created } ++;
     }
     print "OK\n";
-    
+
     print "Import Custom Fields (. = Definition, - = Project relation, + = Issue value)\n";
     my $custom_fields = $dbix_mantis->query( <<SQLRELATIONS );
 SELECT
@@ -1001,7 +1001,7 @@ SELECT
 FROM
     mantis_custom_field_table
 SQLRELATIONS
-    
+
     my @tracker_ids = $dbix_redmine->query( 'SELECT id FROM trackers' )->flat;
     while( my $custom_field_ref = $custom_fields->hash ) {
         print ".";
@@ -1011,7 +1011,7 @@ SQLRELATIONS
                 ? 'list'
                 : $map_ref->{ custom_fields }->{ $custom_field_ref->{ type } }
             ;
-            
+
             my $ref = {
                 name            => substr( $custom_field_ref->{ name }, 0, 30 ),
                 field_format    => $field_format,
@@ -1024,21 +1024,21 @@ SQLRELATIONS
             };
             #$dbix_redmine->insert( custom_fields => $ref );
             #print Dumper $ref;
-            
+
             # there is some issue with multiline .. hmm.. stragen enough:
             my $sql = 'INSERT INTO custom_fields ('. join( ', ', map { "`$_`" } sort keys %$ref ). ') VALUES ('. join( ', ', map { "?" } sort keys %$ref ). ')';
             my @sql_values = map { $ref->{ $_ } } sort keys %$ref;
-            #print "$sql : ". join( ", ", @sql_values ). "\n"; 
+            #print "$sql : ". join( ", ", @sql_values ). "\n";
             $dbix_redmine->query( $sql, @sql_values );
-            
+
             my ( $custom_field_id ) = $dbix_redmine->query( 'SELECT MAX(id) FROM custom_fields' )->list;
-            
+
             # associate with all trackers
             $dbix_redmine->insert( custom_fields_trackers => {
                 custom_field_id => $custom_field_id,
                 tracker_id      => $_
             } ) for @tracker_ids;
-            
+
             # get projects and re-associate fields
             my @assoc_project_ids = $dbix_mantis->query( 'SELECT project_id FROM mantis_custom_field_project_table WHERE field_id = ?', $custom_field_ref->{ id } )->flat;
             #die Dumper { assoc => \@assoc_project_ids, projects => $map_ref->{ projects } };
@@ -1049,8 +1049,8 @@ SQLRELATIONS
                     project_id      => $map_ref->{ projects }->{ $pid }
                 } );
             }
-            
-            
+
+
             # set all custom field values to issues
             my $custom_field_values = $dbix_mantis->query( 'SELECT bug_id, value FROM mantis_custom_field_string_table WHERE field_id = ?', $custom_field_ref->{ id } );
             while( my $field_value_ref = $custom_field_values->hash ) {
@@ -1063,11 +1063,11 @@ SQLRELATIONS
                 } );
             }
         }
-        
+
         $report{ custom_fields_created } ++;
     }
     print "OK\n";
-    
+
     print "\n\nAll Done\n";
     printf "%-40s : %5d / %5d\n", 'Users (migrated/created)', $report{ users_migrated } || 0, $report{ users_created } || 0;
     printf "%-40s : %5d / %5d\n", 'Projects (migrated/created)', $report{ projects_migrated } || 0, $report{ projects_created } || 0;
@@ -1085,9 +1085,9 @@ SQLRELATIONS
     }
     else {
         print "** Import completed, have fun! **\n";
-        print "You should copy now all extracted files from '$opt{ attachment_dir }/' to your attachment directory of redmine (usually '/files' in your redmine install dir)\n"; 
+        print "You should copy now all extracted files from '$opt{ attachment_dir }/' to your attachment directory of redmine (usually '/files' in your redmine install dir)\n";
     }
-    
+
 }
 
 
@@ -1149,8 +1149,8 @@ sub create_map {
         print_mantis  => 0,
         print_redmine => 0
     };
-    
-    
+
+
     my $legend_sub = sub {
         print "Mantis: $name\n";
         foreach my $position( sort keys %$mantis_ref ) {
@@ -1163,7 +1163,7 @@ sub create_map {
         }
         print "\n";
     };
-    
+
     my $translation_sub = sub {
         print "$name translation\n";
         printf "    %-20s ->     %-20s\n", "Mantis", "Redmine";
@@ -1178,17 +1178,17 @@ sub create_map {
     $legend_sub->();
     $translation_sub->();
     my ( $last_mantis ) = ( reverse sort keys %$mantis_ref );
-    
+
     my @request = ();
     my $request_new = $args_ref->{ allow_new } ? " or num:-1 for create as new " : "";
     push @request,"Type 'ok' if you confirm or num:num ${request_new}to change assignment";
-    
+
     my $myname = $default_ref->{ name } || $default_ref->{ login };
     push @request,"  eg $last_mantis:$default_ref->{ $key } to change $name of '$mantis_ref->{ $last_mantis }->[0]' to '$myname'";
     push @request, "  type 'print' to show the Redmine/Mantis tabels again";
     push @request, "(ok/num:num/print)";
     my $request = join( "\n", @request );
-    
+
     my $read = read_in( $request );
     while ( lc( $read ) ne 'ok' ) {
         if ( $read =~ /^(\d+):(\d+)$/ ) {
@@ -1217,7 +1217,7 @@ sub create_map {
         }
         $read = read_in( $request );
     }
-    
+
     # return map of ( number => id )
     return { map {
         ( $_ => $mantis_ref->{ $_ }->[1] );

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -199,7 +199,7 @@ unless ( $DRY || read_in( "Are you sure you? Do you have a backup of your import
 my $dbix_mantis = DBIx::Simple->connect(
     'DBI:mysql:database='. $opt{ mantis_db_name }. ';host='. $opt{ mantis_db_host },
     $opt{ mantis_db_login }, $opt{ mantis_db_pass },
-    { RaiseError => 1 }
+    { RaiseError => 1, mysql_enable_utf8 => 1},
 );
 my $dbix_redmine = DBIx::Simple->connect(
     'DBI:mysql:database='. $opt{ redmine_db_name }. ';host='. $opt{ redmine_db_host },

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -961,7 +961,7 @@ SQLNOTES
                 unless ( $DRY ) {
 
                     # write file to disk
-                    my $filename = "$attachment_ref->{ diskfile }_$attachment_ref->{ filename }";
+                    my $filename = "$attachment_ref->{ diskfile }";
                     my $output = "$opt{ attachment_dir }/$filename";
                     open my $fh, '>', $output or die "Cannot open attachment file '$output' for write: $!";
                     binmode $fh;

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -433,12 +433,10 @@ User interactive.
 
 sub import_versions {
 
-    #my $sql_version_table = 'SELECT id, version, description, project_id, DATE_FORMAT( date, \'%Y-%m-%d\' ) as date, released FROM mantis_project_version_table';
-    my $sql_version_table = 'SELECT id, version, description, project_id, released FROM mantis_project_version_table';
     my %mantis = map {
         $_->{ name } = substr( delete $_->{ version }, 0, 30 );
         ( $_->{ id } => $_ );
-    } $dbix_mantis->query( $sql_version_table )->hashes;
+    } $dbix_mantis->query( 'SELECT id, version, description, project_id, released, FROM_UNIXTIME( date_order, \'%Y-%m-%d\' ) as effective_date FROM mantis_project_version_table' )->hashes;
 
     my %redmine = map {
         ( $_->{ id } => $_ );
@@ -724,7 +722,7 @@ sub perform_import {
                     description     => $new_ref->{ description },
                     project_id      => $project_id,
                     status          => $released,
-                    effective_date  => $new_ref->{ date }
+                    effective_date  => $new_ref->{ effective_date }
                 } );
                 ( $map_ref->{ versions }->{ $old_id } ) = $dbix_redmine->query( 'SELECT MAX(id) FROM versions' )->list;
                 $version_map{ $new_ref->{ name } } = $map_ref->{ versions }->{ $old_id };

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -87,9 +87,6 @@ use DBIx::Simple;
 use Data::Dumper;
 use YAML;
 
-use utf8;
-use Encode;
-
 use version 0.74; our $VERSION = qv(v0.3.1);
 
 # Unbuffered output
@@ -908,8 +905,8 @@ SQLNOTES
                 tracker_id       => ($issue_ref->{ severity } == 10) ? $trackerIdFeature : $trackerIdBug,
                 project_id       => $map_ref->{ projects }->{ $issue_ref->{ project_id } },
                 category_id      => $map_ref->{ categories }->{ $issue_ref->{ category_id } },
-                subject          => encode( "UTF-8", $issue_ref->{ subject } ),
-                description      => encode( "UTF-8", $issue_ref->{ description } ),
+                subject          => $issue_ref->{ subject },
+                description      => $issue_ref->{ description },
                 status_id        => $map_ref->{ stati }->{ $issue_ref->{ status } }->{ id },
                 assigned_to_id   => $map_ref->{ users }->{ $issue_ref->{ handler_id } },
                 priority_id      => $map_ref->{ priorities }->{ $issue_ref->{ priority } }->{ id },
@@ -943,7 +940,7 @@ SQLNOTES
                     journalized_id   => $issue_id,
                     journalized_type => 'Issue',
                     user_id          => $map_ref->{ users }->{ $note_ref->{ reporter_id } } || 2,
-                    notes            => encode( "UTF-8", $note_ref->{ note } ),
+                    notes            => $note_ref->{ note },
                     created_on       => $note_ref->{ created_on },
                 } );
             }
@@ -1090,7 +1087,7 @@ SQLRELATIONS
                     customized_type => 'Issue',
                     customized_id   => $issue_map{ $field_value_ref->{ bug_id } },
                     custom_field_id => $custom_field_id,
-                    value           => encode( "UTF-8", $field_value_ref->{ value } )
+                    value           => $field_value_ref->{ value }
                 } );
             }
         }

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -850,9 +850,9 @@ SELECT
     b.severity,
     c.id as `category_id`,
     b.summary AS `subject`,
-    b.date_submitted AS `created_on`,
-    b.date_submitted AS `start_date`,
-    b.last_updated AS `updated_on`,
+    DATE_FORMAT( FROM_UNIXTIME( b.date_submitted ), '%Y-%m-%d %T' ) AS `created_on`,
+    DATE_FORMAT( FROM_UNIXTIME( b.date_submitted ), '%Y-%m-%d' ) AS `start_date`,
+    DATE_FORMAT( FROM_UNIXTIME( b.last_updated ), '%Y-%m-%d %T' ) AS `updated_on`,
     CONCAT_WS( "\n\n", tt.description, tt.steps_to_reproduce, tt.additional_information ) AS `description`
 FROM mantis_bug_table b
 LEFT JOIN mantis_bug_text_table tt ON ( tt.id = b.bug_text_id )
@@ -862,7 +862,7 @@ SQL
     my $notes_sql = <<SQLNOTES;
 SELECT
     b.reporter_id,
-    b.date_submitted  AS `created_on`,
+    DATE_FORMAT( FROM_UNIXTIME( b.date_submitted ), '%Y-%m-%d %T' ) AS `created_on`,
     tt.note
 FROM mantis_bugnote_table b
 LEFT JOIN mantis_bugnote_text_table tt ON ( tt.id = b.bugnote_text_id )
@@ -875,7 +875,7 @@ SELECT
     b.diskfile,
     b.filename,
     b.file_type,
-    b.date_added AS `created_on`,
+    DATE_FORMAT( FROM_UNIXTIME( b.date_added ), '%Y-%m-%d %T' ) AS `created_on`,
     CONCAT_WS( "\n", b.title, b.description ) AS `description`,
     b.content
 FROM mantis_bug_file_table b

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -810,18 +810,17 @@ sub perform_import {
                 # get category probs
                 my $name       = delete $new_ref->{ name };
                 my $user_id    = delete $new_ref->{ assigned_to_id };
-                # link category to project(s)
+                # link category to project
                 my $project_id = $map_ref->{ projects }->{ delete $new_ref->{ project_id } } ;
-                my @insert = $project_id == 0 ? @project_ids : $project_id ;
 
                 unless ( $DRY ) {
 
-                    foreach my $insert( @insert ) {
-                    # create category
+                    unless ( $project_id == 0 ) {
+                        # create category
                         $dbix_redmine->insert( issue_categories => {
                             name           => $name,
                             assigned_to_id => $map_ref->{ users }->{ $user_id },
-                            project_id     => $insert
+                            project_id     => $project_id
                         } );
                     }
                     ( $map_ref->{ categories }->{ $old_id } ) = $dbix_redmine->query( 'SELECT MAX(id) FROM issue_categories' )->list;

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -387,7 +387,7 @@ sub import_projects {
     my %mantis = map {
         $_->{ name } => $_->{ name };
         ( $_->{ id } => $_ );
-    } $dbix_mantis->query( 'SELECT id, name FROM mantis_project_table' )->hashes;
+    } $dbix_mantis->query( 'SELECT id, name, description FROM mantis_project_table' )->hashes;
     my ( $first_mantis_id ) = sort keys %mantis;
     die "Did not find any mantis projects\n"
         unless $first_mantis_id;
@@ -665,7 +665,6 @@ sub perform_import {
 
                 $dbix_redmine->insert( projects => {
                     %$new_ref, # name
-                    description => 'Imported from Mantis',
                     is_public   => 0,
                     created_on  => \'NOW()',
                     updated_on  => \'NOW()',

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -699,6 +699,15 @@ sub perform_import {
                     name       => 'documents'
                 } );
 
+                # activate trackers in projects
+                #foreach my $tracker_ref ( $dbix_redmine->query( 'SELECT DISTINCT(id) FROM trackers' )->list ) {
+                foreach my $tracker_ref ( 1, 2 ) {
+                    $dbix_redmine->insert( projects_trackers => {
+                        project_id => $map_ref->{ projects }->{ $old_id },
+                        tracker_id => $tracker_ref
+                    } );
+                }
+
                 # Add admins as manager to all projects
                 foreach my $admin_ref ( @mantis_admins ) {
                     $dbix_redmine->insert( members => {

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -1051,6 +1051,7 @@ SQLNOTES
                 created_on       => $issue_ref->{ created_on },
                 updated_on       => $issue_ref->{ updated_on },
                 start_date       => $issue_ref->{ start_date },
+                done_ratio       => ( $issue_ref->{ status } eq 90 ) || ( $issue_ref->{ status } eq 80 ) ? 100 : 0,
                 lft              => 1,
                 rgt              => 2,
                 fixed_version_id => $issue_ref->{ target_version } && defined $version_map{ $issue_ref->{ target_version } }

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -36,7 +36,7 @@ This would require the following packages on a debian system
 
 =item * It says "Load from file" ..
 
-You already ran this script once (eg in dry-run-mode). It will create store-<name>.map files within the current directory to save your answers. If you want to answer one (or all) of the mappings again simply remove the corresponding store-file (name should be self-explanatory.
+You already ran this script once (eg in dry-run-mode). It will create store-<name>.map files within the current directory to save your answers. If you want to answer one (or all) of the mappings again simply remove the corresponding store-file (name should be self-explanatory).
 
 =back
 

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -87,6 +87,9 @@ use DBIx::Simple;
 use Data::Dumper;
 use YAML;
 
+use utf8;
+use Encode;
+
 use version 0.74; our $VERSION = qv(v0.3.1);
 
 # Unbuffered output
@@ -884,8 +887,8 @@ SQLNOTES
                 tracker_id       => ($issue_ref->{ severity } == 10) ? $trackerIdFeature : $trackerIdBug,
                 project_id       => $map_ref->{ projects }->{ $issue_ref->{ project_id } },
                 category_id      => $map_ref->{ projects }->{ $issue_ref->{ category_id } },
-                subject          => $issue_ref->{ subject },
-                description      => $issue_ref->{ description },
+                subject          => encode( "UTF-8", $issue_ref->{ subject } ),
+                description      => encode( "UTF-8", $issue_ref->{ description } ),
                 status_id        => $map_ref->{ stati }->{ $issue_ref->{ status } }->{ id },
                 assigned_to_id   => $map_ref->{ users }->{ $issue_ref->{ handler_id } },
                 priority_id      => $map_ref->{ priorities }->{ $issue_ref->{ priority } }->{ id },
@@ -920,7 +923,7 @@ SQLNOTES
                     journalized_id   => $issue_id,
                     journalized_type => 'Issue',
                     user_id          => $map_ref->{ users }->{ $note_ref->{ reporter_id } },
-                    notes            => $note_ref->{ note },
+                    notes            => encode( "UTF-8", $note_ref->{ note } ),
                     created_on       => $note_ref->{ created_on },
                 } );
             }
@@ -1068,7 +1071,7 @@ SQLRELATIONS
                     customized_type => 'Issue',
                     customized_id   => $issue_map{ $field_value_ref->{ bug_id } },
                     custom_field_id => $custom_field_id,
-                    value           => $field_value_ref->{ value }
+                    value           => encode( "UTF-8", $field_value_ref->{ value } )
                 } );
             }
         }

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -1024,8 +1024,8 @@ SQLNOTES
         #print "$issue_ref->{ id }: $issue_ref->{ target_version } -> $version_map{ $issue_ref->{ target_version } }\n" if $issue_ref->{ target_version };
         #print "is feature: $issue_ref->{ subject } ( $opt{ tracker_id_feature } )\n" if ($issue_ref->{ severity } == 10);
 
-        my $trackerIdFeature = ($opt{ tracker_id_feature }) ? $opt{ tracker_id_feature } : 1;
-        my $trackerIdBug = ($opt{ tracker_id_bug }) ? $opt{ tracker_id_bug } : 2;
+        my $trackerIdFeature = ($opt{ tracker_id_feature }) ? $opt{ tracker_id_feature } : 2;
+        my $trackerIdBug = ($opt{ tracker_id_bug }) ? $opt{ tracker_id_bug } : 1;
 
         unless ( $DRY ) {
             # insert

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -957,7 +957,6 @@ SQLNOTES
             my $attachments = $dbix_mantis->query( $attachments_sql, $issue_ref->{ id } );
             while ( my $attachment_ref = $attachments->hash ) {
                 # we have the attachments in the db -> exit
-                last;
                 print "+";
 
                 unless ( $DRY ) {

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -385,7 +385,7 @@ Non interactive.
 
 sub import_projects {
     my %mantis = map {
-        $_->{ name } = substr( $_->{ name }, 0, 30 );
+        $_->{ name } => $_->{ name };
         ( $_->{ id } => $_ );
     } $dbix_mantis->query( 'SELECT id, name FROM mantis_project_table' )->hashes;
     my ( $first_mantis_id ) = sort keys %mantis;

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -272,7 +272,7 @@ sub import_stati {
         40 => [ "confirmed", $redmine_stati{ 1 } ], # confirmed
         50 => [ "assigned", $redmine_stati{ 2 } || $default_ref ], # assigned
         80 => [ "resolved", $redmine_stati{ 3 } || $default_ref ], # resolved
-        90 => [ "closed", $redmine_stati{ 3 } || $default_ref ]  # closed
+        90 => [ "closed", $redmine_stati{ 5 } || $default_ref ]  # closed
     );
 
     return create_map( 'Status', \%mantis_stati, \%redmine_stati, $default_ref, 'position' );

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -367,10 +367,10 @@ Non interactive.
 sub import_relations {
     return {
         1 => 'relates',    # related to
-        2 => 'relates',    # parent of
-        3 => 'relates',    # child of
+        2 => 'blocked',    # parent of
+        3 => 'blocks',     # child of
         0 => 'duplicates', # duplicate of
-        4 => 'duplicates'  # has duplicate
+        4 => 'duplicated'  # has duplicate
     };
 }
 

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -893,6 +893,8 @@ SQLNOTES
                 created_on       => $issue_ref->{ created_on },
                 updated_on       => $issue_ref->{ updated_on },
                 start_date       => $issue_ref->{ start_date },
+                lft              => 1,
+                rgt              => 2,
                 fixed_version_id => $issue_ref->{ target_version } && defined $version_map{ $issue_ref->{ target_version } }
                     ? $version_map{ $issue_ref->{ target_version } }
                     : 0
@@ -961,6 +963,12 @@ SQLNOTES
         	# we have the attachments in the db -> exit
         }
     }
+
+    unless ( $DRY ) {
+        # set root_id to id for redmine to work properly
+        $dbix_redmine->query( 'UPDATE issues SET root_id=id WHERE root_id IS NULL;' );
+    }
+    
     print "OK\n";
 
     print "Import Relations\n";

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -1122,6 +1122,7 @@ SQLNOTES
                         disk_filename  => $filename,
                         filesize       => -s $output,
                         content_type   => $attachment_ref->{ file_type },
+                        description    => $attachment_ref->{ description },
                         created_on     => $attachment_ref->{ created_on },
                         author_id      => $map_ref->{ users }->{ $attachment_ref->{ user_id } } || 2,
                     } );

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -204,7 +204,7 @@ my $dbix_mantis = DBIx::Simple->connect(
 my $dbix_redmine = DBIx::Simple->connect(
     'DBI:mysql:database='. $opt{ redmine_db_name }. ';host='. $opt{ redmine_db_host },
     $opt{ redmine_db_login }, $opt{ redmine_db_pass },
-    { RaiseError => 1 }
+    { RaiseError => 1, mysql_enable_utf8 => 1}
 );
 
 

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -1110,6 +1110,15 @@ SQLNOTES
                         old_value    => $map_ref->{ stati }->{ $history_ref->{ old_value } }->{ id },
                         value        => $map_ref->{ stati }->{ $history_ref->{ new_value } }->{ id },
                     } );
+                    if ( $history_ref->{ new_value } eq 90 ) {
+                        my %closed_on = ( closed_on =>  $history_ref->{ created_on } );
+                        my %where_issue_id = ( id => $issue_id );
+                        $dbix_redmine->update( 'issues',
+                            \%closed_on,
+                            \%where_issue_id
+                        );
+                    }
+
                 }
 
                 $report{ journals_created } ++;

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -913,7 +913,7 @@ SQLNOTES
                 status_id        => $map_ref->{ stati }->{ $issue_ref->{ status } }->{ id },
                 assigned_to_id   => $map_ref->{ users }->{ $issue_ref->{ handler_id } },
                 priority_id      => $map_ref->{ priorities }->{ $issue_ref->{ priority } }->{ id },
-                author_id        => $map_ref->{ users }->{ $issue_ref->{ reporter_id } },
+                author_id        => $map_ref->{ users }->{ $issue_ref->{ reporter_id } } || 2,
                 created_on       => $issue_ref->{ created_on },
                 updated_on       => $issue_ref->{ updated_on },
                 start_date       => $issue_ref->{ start_date },
@@ -942,7 +942,7 @@ SQLNOTES
                 $dbix_redmine->insert( journals => {
                     journalized_id   => $issue_id,
                     journalized_type => 'Issue',
-                    user_id          => $map_ref->{ users }->{ $note_ref->{ reporter_id } },
+                    user_id          => $map_ref->{ users }->{ $note_ref->{ reporter_id } } || 2,
                     notes            => encode( "UTF-8", $note_ref->{ note } ),
                     created_on       => $note_ref->{ created_on },
                 } );

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -992,7 +992,7 @@ SQLNOTES
         # set root_id to id for redmine to work properly
         $dbix_redmine->query( 'UPDATE issues SET root_id=id WHERE root_id IS NULL;' );
     }
-    
+
     print "OK\n";
 
     print "Import Relations\n";

--- a/mantis2redmine.pl
+++ b/mantis2redmine.pl
@@ -811,7 +811,7 @@ sub perform_import {
 
                 # get category probs
                 my $name       = delete $new_ref->{ name };
-                my $project_id = delete $new_ref->{ project_id };
+                my $project_id = $map_ref->{ projects }->{ delete $new_ref->{ project_id } };
 
                 unless ( $DRY ) {
 


### PR DESCRIPTION
I updated the script to be compatible with newer Mantis/Redmine versions and extended it to import more data. This script has been used to import more than 120 Mantis projects. After the import the Redmine DB has been successfully updated to v3.3.0.

I also included some commits by other developers I found on gabeayers/mantis2redmine which I considered useful.
